### PR TITLE
Add option to open links in VSCode Insiders

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
           "type": "boolean",
           "default": false,
           "description": "Include the column number in the link to the current file and line number"
+        },
+        "hipdotUrlSchemeGrabber.useVSCodeInsiders": {
+          "type": "boolean",
+          "default": false,
+          "description": "Format the link so that it opens in VSCode Insiders instead of VSCode"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,9 +30,12 @@ function copyCurrentFilePathWithCurrentLineNumber(markdown: boolean = false): st
 	const relativePath = path.replace(vscode.workspace.rootPath, '');
 	const lineNumber = editor.selection.active.line + 1;
 	const columnNumber = editor.selection.active.character + 1;
-	const includeColumn = vscode.workspace.getConfiguration('hipdotUrlSchemeGrabber').get('includeColumn');
+	const config = vscode.workspace.getConfiguration('hipdotUrlSchemeGrabber')
+	const includeColumn = config.get('includeColumn');
+	const useVSCodeInsiders = config.get('useVSCodeInsiders');
+	const protocol = useVSCodeInsiders ? 'vscode-insiders': 'vscode'
 
-	const url = `vscode://file${path}:${lineNumber}${includeColumn ? `:${columnNumber}` : ''}`;
+	const url = `${protocol}://file${path}:${lineNumber}${includeColumn ? `:${columnNumber}` : ''}`;
 	return markdown ? `[${relativePath}:${lineNumber}${includeColumn ? `:${columnNumber}` : ''}](${url})` : url;
 };
 


### PR DESCRIPTION
Hi @ebetancourt, thanks for making this! Exactly what I wanted (is it surprising it doesn't exist already?)

This PR adds an option to format the URL so that it opens in VSCode Insiders. I've (quickly) tested it manually.